### PR TITLE
Custom curl options

### DIFF
--- a/src/Auth/AuthAbstract.php
+++ b/src/Auth/AuthAbstract.php
@@ -42,7 +42,7 @@ abstract class AuthAbstract
      * @param SerializerInterface $serializer Output Serializer
      * @throws MissingCredentialsException
      */
-    public function __construct(array $credentials, SerializerInterface $serializer)
+    public function __construct(array $credentials, SerializerInterface $serializer, array $curlOptions = array())
     {
         $this->validateCredentials($credentials);
 
@@ -50,7 +50,7 @@ abstract class AuthAbstract
 
         $this->serializer = $serializer;
 
-        $this->curl = new Curl();
+        $this->curl = new Curl($curlOptions);
 
         unset($credentials, $serializer);
     }

--- a/src/Common/Curl.php
+++ b/src/Common/Curl.php
@@ -17,6 +17,13 @@ use TwitterOAuth\Exception\CurlException;
 
 class Curl
 {
+    private $_options;
+
+    public function __construct($curlOptions = array())
+    {
+        $this->_options	=	$curlOptions;
+    }
+
     /**
      * Send a request
      *
@@ -25,7 +32,7 @@ class Curl
      * @return array  Headers & Body
      * @throws CurlException
      */
-    public function send($url, array $params = array(), array $curl_params = array())
+    public function send($url, array $params = array())
     {
         $out = array();
 
@@ -65,7 +72,7 @@ class Curl
                 CURLOPT_CAINFO => dirname(__DIR__) . '/Certificates/rootca.pem',
                 CURLOPT_USERAGENT => 'TwitterOAuth for v1.1 API (https://github.com/ricardoper/TwitterOAuth)',
             ),
-            $curl_params
+            $this->_options
 		);
 
 

--- a/src/Common/Curl.php
+++ b/src/Common/Curl.php
@@ -25,7 +25,7 @@ class Curl
      * @return array  Headers & Body
      * @throws CurlException
      */
-    public function send($url, array $params = array())
+    public function send($url, array $params = array(), array $curl_params = array())
     {
         $out = array();
 
@@ -38,7 +38,6 @@ class Curl
         );
 
         $params = array_merge($default, $params);
-
 
         // Get Params //
         if (is_array($params['get']) && !empty($params['get'])) {
@@ -53,22 +52,21 @@ class Curl
 
 
         // Curl Options //
-        $options = array(
-            CURLOPT_URL => $url,
-            CURLOPT_HEADER => true,
-            CURLOPT_TIMEOUT => 60,
-            CURLOPT_CONNECTTIMEOUT => 60,
-            CURLOPT_FOLLOWLOCATION => true,
-            CURLOPT_RETURNTRANSFER => true,
-            CURLOPT_SSL_VERIFYPEER => true,
-            CURLOPT_SSL_VERIFYHOST => 2,
-            CURLOPT_CAINFO => dirname(__DIR__) . '/Certificates/rootca.pem',
-            CURLOPT_USERAGENT => 'TwitterOAuth for v1.1 API (https://github.com/ricardoper/TwitterOAuth)',
-
-            // FOR DEBUG ONLY - PROXY SETTINGS //
-            //CURLOPT_PROXY => '127.0.0.1',
-            //CURLOPT_PROXYPORT => 8888,
-        );
+        $options = array_replace(
+            array(
+                CURLOPT_URL => $url,
+                CURLOPT_HEADER => true,
+                CURLOPT_TIMEOUT => 60,
+                CURLOPT_CONNECTTIMEOUT => 60,
+                CURLOPT_FOLLOWLOCATION => true,
+                CURLOPT_RETURNTRANSFER => true,
+                CURLOPT_SSL_VERIFYPEER => true,
+                CURLOPT_SSL_VERIFYHOST => 2,
+                CURLOPT_CAINFO => dirname(__DIR__) . '/Certificates/rootca.pem',
+                CURLOPT_USERAGENT => 'TwitterOAuth for v1.1 API (https://github.com/ricardoper/TwitterOAuth)',
+            ),
+            $curl_params
+		));
 
 
         // Post Params //

--- a/src/Common/Curl.php
+++ b/src/Common/Curl.php
@@ -73,7 +73,7 @@ class Curl
                 CURLOPT_USERAGENT => 'TwitterOAuth for v1.1 API (https://github.com/ricardoper/TwitterOAuth)',
             ),
             $this->_options
-		);
+        );
 
 
         // Post Params //

--- a/src/Common/Curl.php
+++ b/src/Common/Curl.php
@@ -66,7 +66,7 @@ class Curl
                 CURLOPT_USERAGENT => 'TwitterOAuth for v1.1 API (https://github.com/ricardoper/TwitterOAuth)',
             ),
             $curl_params
-		));
+		);
 
 
         // Post Params //

--- a/src/Common/Curl.php
+++ b/src/Common/Curl.php
@@ -19,7 +19,7 @@ class Curl
 {
     private $_options;
 
-    public function __construct($curlOptions = array())
+    public function __construct(array $curlOptions = array())
     {
         $this->_options	=	$curlOptions;
     }


### PR DESCRIPTION
Hi @ricardoper 

The use of https://github.com/ricardoper/TwitterOAuth/blob/v2/src/Common/Curl.php#L61 breaks on hosts that have activated ``openbase_dir``.

Moreover it's not sure this option is required (ref: https://github.com/jmathai/twitter-async/issues/30#issuecomment-93501)

So here is a PR that allows to specify custom CURL rules (which will also helps for managing HTTP proxies).

Thanks!